### PR TITLE
Added admin updates placeholder

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import CourseDescriptionIndexPage from "main/pages/CourseDescriptions/CourseDescriptionIndexPage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
 import AdminLoadSubjectsPage from "main/pages/Admin/AdminLoadSubjectsPage";
 import AdminJobsPage from "main/pages/Admin/AdminJobsPage";
 import DeveloperPage from "main/pages/DeveloperPage"; // route from /developer to DeveloperPage
@@ -34,6 +35,7 @@ function App() {
         {hasRole(currentUser, "ROLE_ADMIN") && (
           <>
             <Route exact path="/admin/users" element={<AdminUsersPage />} />
+            <Route exact path="/admin/updates" element={<AdminUpdatesPage />} />
             <Route
               exact
               path="/admin/loadsubjects"

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,6 +115,12 @@ export default function AppNavbar({
                     Users
                   </NavDropdown.Item>
                   <NavDropdown.Item
+                    href="/admin/updates"
+                    data-testid="appnavbar-admin-updates"
+                  >
+                    Updates
+                  </NavDropdown.Item>
+                  <NavDropdown.Item
                     href="/admin/personalschedule"
                     data-testid="appnavbar-admin-personalschedule"
                   >

--- a/frontend/src/main/pages/Admin/AdminUpdatesPage.js
+++ b/frontend/src/main/pages/Admin/AdminUpdatesPage.js
@@ -1,0 +1,9 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminUpdatesPage() {
+  return (
+    <BasicLayout>
+      <h2>Updates</h2>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
+++ b/frontend/src/stories/pages/Admin/AdminUpdatesPage.stories.js
@@ -1,0 +1,10 @@
+import React from "react";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
+
+export default {
+  title: "pages/Admin/AdminUpdatesPage",
+  component: AdminUpdatesPage,
+};
+
+const Template = () => <AdminUpdatesPage />;
+export const Default = Template.bind({});

--- a/frontend/src/tests/pages/AdminUpdatesPage.test.js
+++ b/frontend/src/tests/pages/AdminUpdatesPage.test.js
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage.js";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("AdminUpdatesPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+    setupUserOnly();
+
+    // act
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminUpdatesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // assert
+    await screen.findByText("Updates");
+  });
+});


### PR DESCRIPTION
Closes [#12]

<img width="1366" alt="Screenshot 2024-11-20 at 2 37 27 PM" src="https://github.com/user-attachments/assets/7b0a1c6a-19fe-4fe5-8893-35f76a796166">

As shown above, we can now see the "Updates" option for the Admin tab dropdown on the Navbar. This is only accessible for admins as specified in `ADMIN_EMAILS`. Changes to the Navbar were reflected in the files `App.js` and `AppNavbar.js`. 