### PR TITLE
Add Purge Job Log Button to Admin Jobs Page

### DIFF
--- a/frontend/src/main/pages/Admin/AdminJobsPage.js
+++ b/frontend/src/main/pages/Admin/AdminJobsPage.js
@@ -2,6 +2,7 @@ import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 import JobsTable from "main/components/Jobs/JobsTable";
 import { useBackend } from "main/utils/useBackend";
+import { Button } from "react-bootstrap";
 import Accordion from "react-bootstrap/Accordion";
 import TestJobForm from "main/components/Jobs/TestJobForm";
 import UpdateGradeInfoForm from "main/components/Jobs/UpdateGradeInfoForm";
@@ -29,6 +30,25 @@ const AdminJobsPage = () => {
 
   const submitTestJob = async (data) => {
     testJobMutation.mutate(data);
+  };
+
+  // purge job
+
+  const objectToAxiosParamsPurgeJobLog = () => ({
+    url: "/api/jobs/all",
+    method: "DELETE",
+  });
+
+  // Stryker disable all
+  const purgeJobLogMutation = useBackendMutation(
+    objectToAxiosParamsPurgeJobLog,
+    {},
+    ["/api/jobs/all"],
+  );
+  // Stryker restore all
+
+  const purgeJobLog = async () => {
+    purgeJobLogMutation.mutate();
   };
 
   // ***** update courses job *******
@@ -156,6 +176,9 @@ const AdminJobsPage = () => {
       <h2 className="p-3">Job Status</h2>
 
       <JobsTable jobs={jobs} />
+      <Button variant="danger" onClick={purgeJobLog} data-testid="purgeJobLog">
+        Purge Job Log
+      </Button>
     </BasicLayout>
   );
 };

--- a/frontend/src/tests/pages/AdminJobsPage.test.js
+++ b/frontend/src/tests/pages/AdminJobsPage.test.js
@@ -255,4 +255,26 @@ describe("AdminJobsPage tests", () => {
     await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
     expect(axiosMock.history.post[0].url).toBe(url);
   });
+
+  test("user can purge all jobs in the JobsTable", async () => {
+    axiosMock.onDelete("/api/jobs/all").reply(200, {});
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminJobsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Purge Job Log")).toBeInTheDocument();
+
+    const purgeAllLogsButton = screen.getByText("Purge Job Log");
+    expect(purgeAllLogsButton).toBeInTheDocument();
+    purgeAllLogsButton.click();
+
+    await waitFor(() => expect(axiosMock.history.delete.length).toBe(1));
+
+    expect(axiosMock.history.delete[0].url).toBe("/api/jobs/all");
+  });
 });


### PR DESCRIPTION
https://github.com/user-attachments/assets/981237ce-1dc1-41cc-9de8-7d26555b63cd

Admin users can initiate jobs from the admin jobs page, and each triggered job is recorded in a job log displayed on the same page. However, there is currently no way to delete entries from the job log, resulting in unnecessary clutter and increased latency. This feature introduces a button to remove individual log entries, allowing administrators to manage the size of the job log effectively. Closes #9.

Link to deployment: https://courses-dev-realweston34.dokku-01.cs.ucsb.edu/