### PR TITLE
COURSES-1: Duplicate personalschedules edit bug fixed

### DIFF
--- a/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
+++ b/frontend/src/main/pages/PersonalSchedules/PersonalSchedulesEditPage.js
@@ -4,6 +4,7 @@ import PersonalScheduleForm from "main/components/PersonalSchedules/PersonalSche
 import { Navigate } from "react-router-dom";
 import { useBackend, useBackendMutation } from "main/utils/useBackend";
 import { Button } from "react-bootstrap";
+import { toast } from "react-toastify";
 
 export default function PersonalSchedulesEditPage() {
   const createButton = () => {
@@ -47,9 +48,15 @@ export default function PersonalSchedulesEditPage() {
     },
   });
 
+  const onSuccess = () => {};
+
+  const onError = (error) => {
+    toast(`Error: ${error.response.data.message}`);
+  };
+
   const mutation = useBackendMutation(
     objectToAxiosParams,
-    {},
+    { onSuccess, onError },
     // Stryker disable next-line all : hard to set up test for caching
     [`/api/personalschedules/id=${id}`],
   );

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -300,7 +300,6 @@ describe("PersonalSchedulesEditPage tests", () => {
           "A personal schedule with that name already exists in that quarter",
       };
 
-      // Mock the duplicate name error
       axiosMock.onPut("/api/personalschedules").reply(404, error);
 
       render(

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -319,9 +319,6 @@ describe("PersonalSchedulesEditPage tests", () => {
       const descriptionField = screen.getByTestId(
         "PersonalScheduleForm-description",
       );
-      const quarterField = document.querySelector(
-        "#PersonalScheduleForm-quarter",
-      );
       const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
 
       fireEvent.change(nameField, { target: { value: "W22b" } });

--- a/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
+++ b/frontend/src/tests/pages/PersonalSchedules/PersonalSchedulesEditPage.test.js
@@ -255,5 +255,86 @@ describe("PersonalSchedulesEditPage tests", () => {
         </QueryClientProvider>,
       );
     });
+
+    test("when the backend returns an error, user gets toast with error message", async () => {
+      const queryClient = new QueryClient();
+      axiosMock
+        .onPut("/api/personalschedules")
+        .reply(500, { message: "The backend is in a mood today" });
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        await screen.findByTestId("PersonalScheduleForm-name"),
+      ).toBeInTheDocument();
+
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      fireEvent.change(nameField, { target: { value: "SampName" } });
+      fireEvent.change(descriptionField, { target: { value: "desc" } });
+
+      expect(submitButton).toBeInTheDocument();
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
+
+      expect(mockToast).toHaveBeenCalledWith(
+        "Error: The backend is in a mood today",
+      );
+    });
+
+    test("editing a personal schedule to a duplicate name returns an error", async () => {
+      const queryClient = new QueryClient();
+      const error = {
+        message:
+          "A personal schedule with that name already exists in that quarter",
+      };
+
+      // Mock the duplicate name error
+      axiosMock.onPut("/api/personalschedules").reply(404, error);
+
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter>
+            <PersonalSchedulesEditPage />
+          </MemoryRouter>
+        </QueryClientProvider>,
+      );
+
+      expect(
+        await screen.findByTestId("PersonalScheduleForm-name"),
+      ).toBeInTheDocument();
+
+      const nameField = screen.getByTestId("PersonalScheduleForm-name");
+      const descriptionField = screen.getByTestId(
+        "PersonalScheduleForm-description",
+      );
+      const quarterField = document.querySelector(
+        "#PersonalScheduleForm-quarter",
+      );
+      const submitButton = screen.getByTestId("PersonalScheduleForm-submit");
+
+      fireEvent.change(nameField, { target: { value: "W22b" } });
+      fireEvent.change(descriptionField, {
+        target: { value: "Attempted duplicate" },
+      });
+
+      expect(submitButton).toBeInTheDocument();
+
+      fireEvent.click(submitButton);
+
+      await waitFor(() => expect(axiosMock.history.put.length).toBe(1));
+      expect(axiosMock.history.put[0].data).toContain('"name":"W22b"');
+    });
   });
 });

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -159,6 +159,15 @@ public class PersonalSchedulesController extends ApiController {
             .findByIdAndUser(id, currentUser)
             .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
+    Optional<PersonalSchedule> duplicateCheck =
+    personalscheduleRepository.findByUserAndNameAndQuarter(
+        currentUser, incomingSchedule.getName(), incomingSchedule.getQuarter());
+
+    if (duplicateCheck.isPresent() && (duplicateCheck.get().getId() != id)) {
+      throw new IllegalArgumentException(
+          "A personal schedule with that name already exists in that quarter");
+    }
+
     personalschedule.setName(incomingSchedule.getName());
     personalschedule.setDescription(incomingSchedule.getDescription());
     personalschedule.setQuarter(incomingSchedule.getQuarter());

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -163,7 +163,7 @@ public class PersonalSchedulesController extends ApiController {
         personalscheduleRepository.findByUserAndNameAndQuarter(
             currentUser, incomingSchedule.getName(), incomingSchedule.getQuarter());
 
-    if (duplicateCheck.isPresent() && (duplicateCheck.get().getId() != id)) {
+    if (duplicateCheck.isPresent()) {
       throw new IllegalArgumentException(
           "A personal schedule with that name already exists in that quarter");
     }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -160,8 +160,8 @@ public class PersonalSchedulesController extends ApiController {
             .orElseThrow(() -> new EntityNotFoundException(PersonalSchedule.class, id));
 
     Optional<PersonalSchedule> duplicateCheck =
-    personalscheduleRepository.findByUserAndNameAndQuarter(
-        currentUser, incomingSchedule.getName(), incomingSchedule.getQuarter());
+        personalscheduleRepository.findByUserAndNameAndQuarter(
+            currentUser, incomingSchedule.getName(), incomingSchedule.getQuarter());
 
     if (duplicateCheck.isPresent() && (duplicateCheck.get().getId() != id)) {
       throw new IllegalArgumentException(

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -163,15 +163,16 @@ public class PersonalSchedulesController extends ApiController {
     Iterable<PersonalSchedule> allSchedules =
         personalscheduleRepository.findAllByUserId(currentUser.getId());
 
-    boolean duplicateExists =
+    long duplicateCount =
         StreamSupport.stream(allSchedules.spliterator(), false)
-            .anyMatch(
+            .filter(
                 schedule ->
-                    schedule.getName().equals(incomingSchedule.getName())
-                        && schedule.getQuarter().equals(incomingSchedule.getQuarter())
-                        && schedule.getId() != id);
+                    schedule.getId() != incomingSchedule.getId()
+                        && schedule.getName().equals(incomingSchedule.getName())
+                        && schedule.getQuarter().equals(incomingSchedule.getQuarter()))
+            .count();
 
-    if (duplicateExists) {
+    if (duplicateCount > 0) {
       throw new IllegalArgumentException(
           "A personal schedule with that name already exists in that quarter");
     }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesController.java
@@ -163,16 +163,15 @@ public class PersonalSchedulesController extends ApiController {
     Iterable<PersonalSchedule> allSchedules =
         personalscheduleRepository.findAllByUserId(currentUser.getId());
 
-    long duplicateCount =
+    boolean hasDuplicate =
         StreamSupport.stream(allSchedules.spliterator(), false)
-            .filter(
+            .anyMatch(
                 schedule ->
-                    schedule.getId() != incomingSchedule.getId()
-                        && schedule.getName().equals(incomingSchedule.getName())
-                        && schedule.getQuarter().equals(incomingSchedule.getQuarter()))
-            .count();
+                    schedule.getName().equals(incomingSchedule.getName())
+                        && schedule.getQuarter().equals(incomingSchedule.getQuarter())
+                        && schedule.getId() != personalschedule.getId());
 
-    if (duplicateCount > 0) {
+    if (hasDuplicate) {
       throw new IllegalArgumentException(
           "A personal schedule with that name already exists in that quarter");
     }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -921,159 +921,112 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
         "A personal schedule with that name already exists in that quarter", json.get("message"));
   }
 
-  //   @WithMockUser(roles = {"ADMIN", "USER"})
-  //   @Test
-  //   public void can_edit_personal_schedule_with_unique_name_and_quarter() throws Exception {
-  //     User thisUser = currentUserService.getCurrentUser().getUser();
-
-  //     PersonalSchedule existingSchedule =
-  //         PersonalSchedule.builder()
-  //             .name("TestName")
-  //             .description("Existing description")
-  //             .quarter("20222")
-  //             .user(thisUser)
-  //             .id(1L)
-  //             .build();
-
-  //     PersonalSchedule incomingSchedule =
-  //         PersonalSchedule.builder()
-  //             .name("TestName")
-  //             .description("Updated description")
-  //             .quarter("20222")
-  //             .user(thisUser)
-  //             .id(1L)
-  //             .build();
-
-  //     when(personalscheduleRepository.findByIdAndUser(1L, thisUser))
-  //         .thenReturn(Optional.of(existingSchedule));
-  //     when(personalscheduleRepository.findAllByUserId(thisUser.getId()))
-  //         .thenReturn(Arrays.asList(existingSchedule, incomingSchedule));
-
-  //     MvcResult response =
-  //         mockMvc
-  //             .perform(
-  //                 put("/api/personalschedules?id=1")
-  //                     .with(csrf())
-  //                     .contentType(MediaType.APPLICATION_JSON)
-  //                     .content(
-  //                         "{\"name\":\"TestName\", \"description\":\"Updated description\",
-  // \"quarter\":\"20222\"}"))
-  //             .andExpect(status().isOk())
-  //             .andReturn();
-
-  //     // Parse the response into PersonalSchedule
-  //     String responseBody = response.getResponse().getContentAsString();
-  //     assertTrue(responseBody.contains("Updated description"));
-  //   }
-  
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void test_personal_schedule_duplicate_check() throws Exception {
-      User thisUser = currentUserService.getCurrentUser().getUser();
-  
-      // Existing schedules
-      PersonalSchedule existingSchedule1 =
-          PersonalSchedule.builder()
-              .name("TestName")
-              .quarter("20222")
-              .description("Existing description 1")
-              .user(thisUser)
-              .id(1L)
-              .build();
-  
-      PersonalSchedule existingSchedule2 =
-          PersonalSchedule.builder()
-              .name("AnotherName")
-              .quarter("20222")
-              .description("Existing description 2")
-              .user(thisUser)
-              .id(3L)
-              .build();
-  
-      Iterable<PersonalSchedule> allSchedules =
-          Arrays.asList(existingSchedule1, existingSchedule2);
-  
-      // Case 1: Same name and same quarter (Should detect as duplicate)
-      PersonalSchedule incomingSchedule1 =
-          PersonalSchedule.builder()
-              .name("TestName")
-              .quarter("20222")
-              .description("Updated description")
-              .id(3L)
-              .user(thisUser)
-              .build();
-  
-      when(personalscheduleRepository.findAllByUserId(thisUser.getId())).thenReturn(allSchedules);
-  
-      boolean duplicateExists1 =
-          StreamSupport.stream(allSchedules.spliterator(), false)
-              .anyMatch(
-                  schedule ->
-                      schedule.getName().equals(incomingSchedule1.getName()) &&
-                      schedule.getQuarter().equals(incomingSchedule1.getQuarter()) &&
-                      schedule.getId() != incomingSchedule1.getId());
-  
-      assertTrue(duplicateExists1);
-  
-      // Case 2: Same name but different quarter (Should NOT detect as duplicate)
-      PersonalSchedule incomingSchedule2 =
-          PersonalSchedule.builder()
-              .name("TestName")
-              .quarter("20223")
-              .description("Updated description")
-              .id(4L) 
-              .user(thisUser)
-              .build();
-  
-      boolean duplicateExists2 =
-          StreamSupport.stream(allSchedules.spliterator(), false)
-              .anyMatch(
-                  schedule ->
-                      schedule.getName().equals(incomingSchedule2.getName()) &&
-                      schedule.getQuarter().equals(incomingSchedule2.getQuarter()) &&
-                      schedule.getId() != incomingSchedule2.getId());
-  
-      assertFalse(duplicateExists2);
-  
-      // Case 3: Same quarter but different name (Should NOT detect as duplicate)
-      PersonalSchedule incomingSchedule3 =
-          PersonalSchedule.builder()
-              .name("DifferentName")
-              .quarter("20222")
-              .description("Different description")
-              .id(5L)
-              .user(thisUser)
-              .build();
-  
-      boolean duplicateExists3 =
-          StreamSupport.stream(allSchedules.spliterator(), false)
-              .anyMatch(
-                  schedule ->
-                      schedule.getName().equals(incomingSchedule3.getName()) &&
-                      schedule.getQuarter().equals(incomingSchedule3.getQuarter()) &&
-                      schedule.getId() != incomingSchedule3.getId());
-  
-      assertFalse(duplicateExists3);
-  
+    User thisUser = currentUserService.getCurrentUser().getUser();
+
+    // Existing schedules
+    PersonalSchedule existingSchedule1 =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .quarter("20222")
+            .description("Existing description 1")
+            .user(thisUser)
+            .id(1L)
+            .build();
+
+    PersonalSchedule existingSchedule2 =
+        PersonalSchedule.builder()
+            .name("AnotherName")
+            .quarter("20222")
+            .description("Existing description 2")
+            .user(thisUser)
+            .id(3L)
+            .build();
+
+    Iterable<PersonalSchedule> allSchedules = Arrays.asList(existingSchedule1, existingSchedule2);
+
+    // Case 1: Same name and same quarter (Should detect as duplicate)
+    PersonalSchedule incomingSchedule1 =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .quarter("20222")
+            .description("Updated description")
+            .id(3L)
+            .user(thisUser)
+            .build();
+
+    when(personalscheduleRepository.findAllByUserId(thisUser.getId())).thenReturn(allSchedules);
+
+    boolean duplicateExists1 =
+        StreamSupport.stream(allSchedules.spliterator(), false)
+            .anyMatch(
+                schedule ->
+                    schedule.getName().equals(incomingSchedule1.getName())
+                        && schedule.getQuarter().equals(incomingSchedule1.getQuarter())
+                        && schedule.getId() != incomingSchedule1.getId());
+
+    assertTrue(duplicateExists1);
+
+    // Case 2: Same name but different quarter (Should NOT detect as duplicate)
+    PersonalSchedule incomingSchedule2 =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .quarter("20223")
+            .description("Updated description")
+            .id(4L)
+            .user(thisUser)
+            .build();
+
+    boolean duplicateExists2 =
+        StreamSupport.stream(allSchedules.spliterator(), false)
+            .anyMatch(
+                schedule ->
+                    schedule.getName().equals(incomingSchedule2.getName())
+                        && schedule.getQuarter().equals(incomingSchedule2.getQuarter())
+                        && schedule.getId() != incomingSchedule2.getId());
+
+    assertFalse(duplicateExists2);
+
+    // Case 3: Same quarter but different name (Should NOT detect as duplicate)
+    PersonalSchedule incomingSchedule3 =
+        PersonalSchedule.builder()
+            .name("DifferentName")
+            .quarter("20222")
+            .description("Different description")
+            .id(5L)
+            .user(thisUser)
+            .build();
+
+    boolean duplicateExists3 =
+        StreamSupport.stream(allSchedules.spliterator(), false)
+            .anyMatch(
+                schedule ->
+                    schedule.getName().equals(incomingSchedule3.getName())
+                        && schedule.getQuarter().equals(incomingSchedule3.getQuarter())
+                        && schedule.getId() != incomingSchedule3.getId());
+
+    assertFalse(duplicateExists3);
+
     //   Case 4: Different name and different quarter (Should NOT detect as duplicate)
-      PersonalSchedule incomingSchedule4 =
-          PersonalSchedule.builder()
-              .name("DifferentName")
-              .quarter("20223")
-              .description("Different description")
-              .id(6L)
-              .user(thisUser)
-              .build();
-  
-      boolean duplicateExists4 =
-          StreamSupport.stream(allSchedules.spliterator(), false)
-              .anyMatch(
-                  schedule ->
-                      schedule.getName().equals(incomingSchedule4.getName()) &&
-                      schedule.getQuarter().equals(incomingSchedule4.getQuarter()) &&
-                      schedule.getId() != incomingSchedule4.getId());
-  
-      assertFalse(duplicateExists4); 
+    PersonalSchedule incomingSchedule4 =
+        PersonalSchedule.builder()
+            .name("DifferentName")
+            .quarter("20223")
+            .description("Different description")
+            .id(6L)
+            .user(thisUser)
+            .build();
+
+    boolean duplicateExists4 =
+        StreamSupport.stream(allSchedules.spliterator(), false)
+            .anyMatch(
+                schedule ->
+                    schedule.getName().equals(incomingSchedule4.getName())
+                        && schedule.getQuarter().equals(incomingSchedule4.getQuarter())
+                        && schedule.getId() != incomingSchedule4.getId());
+
+    assertFalse(duplicateExists4);
   }
-  
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -1,8 +1,6 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -922,61 +920,69 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
   public void test_personal_schedule_duplicate_check() throws Exception {
-      User thisUser = currentUserService.getCurrentUser().getUser();
-  
-      PersonalSchedule existingSchedule1 =
-          PersonalSchedule.builder()
-              .name("TestName")
-              .quarter("20222")
-              .description("Existing description 1")
-              .user(thisUser)
-              .id(1L)
-              .build();
-  
-      PersonalSchedule existingSchedule2 =
-          PersonalSchedule.builder()
-              .name("TestName")
-              .quarter("20223")
-              .description("Existing description 2")
-              .user(thisUser)
-              .id(2L)
-              .build();
+    User thisUser = currentUserService.getCurrentUser().getUser();
 
-      Iterable<PersonalSchedule> allSchedules =
-          Arrays.asList(existingSchedule1, existingSchedule2);
-  
-      when(personalscheduleRepository.findAllByUserId(thisUser.getId())).thenReturn(allSchedules);
-  
-      // Test all 8 cases using the helper method
-      assertDuplicateCount("TestName", "20222", 3L, 1L, 1, allSchedules, thisUser);
-      assertDuplicateCount("TestName", "20224", 4L, 4L, 0, allSchedules, thisUser);
-      assertDuplicateCount("DifferentName", "20222", 5L, 5L, 0, allSchedules, thisUser);
-      assertDuplicateCount("DifferentName", "20223", 6L, 6L, 0, allSchedules, thisUser);
-      assertDuplicateCount("TestName", "20222", 1L, 1L, 0, allSchedules, thisUser);
-      assertDuplicateCount("TestName", "20224", 1L, 1L, 0, allSchedules, thisUser);
-      assertDuplicateCount("DifferentName", "20222", 1L, 1L, 0, allSchedules, thisUser);
-      assertDuplicateCount("DifferentName", "20223", 1L, 1L, 0, allSchedules, thisUser);
+    PersonalSchedule existingSchedule1 =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .quarter("20222")
+            .description("Existing description 1")
+            .user(thisUser)
+            .id(1L)
+            .build();
+
+    PersonalSchedule existingSchedule2 =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .quarter("20223")
+            .description("Existing description 2")
+            .user(thisUser)
+            .id(2L)
+            .build();
+
+    Iterable<PersonalSchedule> allSchedules = Arrays.asList(existingSchedule1, existingSchedule2);
+
+    when(personalscheduleRepository.findAllByUserId(thisUser.getId())).thenReturn(allSchedules);
+
+    // Test all 8 cases using the helper method
+    assertDuplicateCount("TestName", "20222", 3L, 1L, 1, allSchedules, thisUser);
+    assertDuplicateCount("TestName", "20224", 4L, 4L, 0, allSchedules, thisUser);
+    assertDuplicateCount("DifferentName", "20222", 5L, 5L, 0, allSchedules, thisUser);
+    assertDuplicateCount("DifferentName", "20223", 6L, 6L, 0, allSchedules, thisUser);
+    assertDuplicateCount("TestName", "20222", 1L, 1L, 0, allSchedules, thisUser);
+    assertDuplicateCount("TestName", "20224", 1L, 1L, 0, allSchedules, thisUser);
+    assertDuplicateCount("DifferentName", "20222", 1L, 1L, 0, allSchedules, thisUser);
+    assertDuplicateCount("DifferentName", "20223", 1L, 1L, 0, allSchedules, thisUser);
   }
-  
-  // Helper method for counting duplicates based on schedule name, quarter, incoming ID, and expected count
-  private void assertDuplicateCount(String name, String quarter, long incomingId, long idToCompare, long expectedCount, Iterable<PersonalSchedule> allSchedules, User thisUser) {
-      PersonalSchedule incomingSchedule = 
-          PersonalSchedule.builder()
-              .name(name)
-              .quarter(quarter)
-              .description("Updated description")
-              .id(incomingId)
-              .user(thisUser)
-              .build();
-  
-      long duplicateCount = StreamSupport.stream(allSchedules.spliterator(), false)
-          .filter(schedule ->
-              schedule.getName().equals(incomingSchedule.getName()) &&
-              schedule.getQuarter().equals(incomingSchedule.getQuarter()) &&
-              schedule.getId() != incomingSchedule.getId())
-          .count();
-  
-      assertEquals(expectedCount, duplicateCount);
+
+  // Helper method for counting duplicates based on schedule name, quarter, incoming ID, and
+  // expected count
+  private void assertDuplicateCount(
+      String name,
+      String quarter,
+      long incomingId,
+      long idToCompare,
+      long expectedCount,
+      Iterable<PersonalSchedule> allSchedules,
+      User thisUser) {
+    PersonalSchedule incomingSchedule =
+        PersonalSchedule.builder()
+            .name(name)
+            .quarter(quarter)
+            .description("Updated description")
+            .id(incomingId)
+            .user(thisUser)
+            .build();
+
+    long duplicateCount =
+        StreamSupport.stream(allSchedules.spliterator(), false)
+            .filter(
+                schedule ->
+                    schedule.getName().equals(incomingSchedule.getName())
+                        && schedule.getQuarter().equals(incomingSchedule.getQuarter())
+                        && schedule.getId() != incomingSchedule.getId())
+            .count();
+
+    assertEquals(expectedCount, duplicateCount);
   }
-  
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PersonalSchedulesControllerTests.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.courses.controllers;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -21,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.StreamSupport;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -846,6 +849,36 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
 
   @WithMockUser(roles = {"ADMIN", "USER"})
   @Test
+  public void cannot_add_two_personal_schedules_with_same_name_and_quarter() throws Exception {
+    User thisUser = currentUserService.getCurrentUser().getUser();
+
+    PersonalSchedule existingSchedule =
+        PersonalSchedule.builder()
+            .name("TestName")
+            .description("Existing description")
+            .quarter("20222")
+            .user(thisUser)
+            .id(1L)
+            .build();
+
+    when(personalscheduleRepository.findByUserAndNameAndQuarter(thisUser, "TestName", "20222"))
+        .thenReturn(Optional.of(existingSchedule));
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/personalschedules/post?name=TestName&description=New description&quarter=20222")
+                    .with(csrf()))
+            .andExpect(status().isBadRequest())
+            .andReturn();
+
+    Map<String, Object> json = responseToJson(response);
+    assertEquals(
+        "A personal schedule with that name already exists in that quarter", json.get("message"));
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
   public void cannot_edit_personal_schedule_to_same_name_and_quarter() throws Exception {
     User thisUser = currentUserService.getCurrentUser().getUser();
 
@@ -858,10 +891,10 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
             .id(1L)
             .build();
 
-    PersonalSchedule conflictingSchedule =
+    PersonalSchedule incomingSchedule =
         PersonalSchedule.builder()
             .name("TestName")
-            .description("Conflicting description")
+            .description("Incoming description")
             .quarter("20222")
             .user(thisUser)
             .id(2L)
@@ -870,7 +903,7 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     when(personalscheduleRepository.findByIdAndUser(1L, thisUser))
         .thenReturn(Optional.of(existingSchedule));
     when(personalscheduleRepository.findAllByUserId(thisUser.getId()))
-        .thenReturn(Arrays.asList(existingSchedule, conflictingSchedule));
+        .thenReturn(Arrays.asList(existingSchedule, incomingSchedule));
 
     MvcResult response =
         mockMvc
@@ -887,4 +920,160 @@ public class PersonalSchedulesControllerTests extends ControllerTestCase {
     assertEquals(
         "A personal schedule with that name already exists in that quarter", json.get("message"));
   }
+
+  //   @WithMockUser(roles = {"ADMIN", "USER"})
+  //   @Test
+  //   public void can_edit_personal_schedule_with_unique_name_and_quarter() throws Exception {
+  //     User thisUser = currentUserService.getCurrentUser().getUser();
+
+  //     PersonalSchedule existingSchedule =
+  //         PersonalSchedule.builder()
+  //             .name("TestName")
+  //             .description("Existing description")
+  //             .quarter("20222")
+  //             .user(thisUser)
+  //             .id(1L)
+  //             .build();
+
+  //     PersonalSchedule incomingSchedule =
+  //         PersonalSchedule.builder()
+  //             .name("TestName")
+  //             .description("Updated description")
+  //             .quarter("20222")
+  //             .user(thisUser)
+  //             .id(1L)
+  //             .build();
+
+  //     when(personalscheduleRepository.findByIdAndUser(1L, thisUser))
+  //         .thenReturn(Optional.of(existingSchedule));
+  //     when(personalscheduleRepository.findAllByUserId(thisUser.getId()))
+  //         .thenReturn(Arrays.asList(existingSchedule, incomingSchedule));
+
+  //     MvcResult response =
+  //         mockMvc
+  //             .perform(
+  //                 put("/api/personalschedules?id=1")
+  //                     .with(csrf())
+  //                     .contentType(MediaType.APPLICATION_JSON)
+  //                     .content(
+  //                         "{\"name\":\"TestName\", \"description\":\"Updated description\",
+  // \"quarter\":\"20222\"}"))
+  //             .andExpect(status().isOk())
+  //             .andReturn();
+
+  //     // Parse the response into PersonalSchedule
+  //     String responseBody = response.getResponse().getContentAsString();
+  //     assertTrue(responseBody.contains("Updated description"));
+  //   }
+  
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void test_personal_schedule_duplicate_check() throws Exception {
+      User thisUser = currentUserService.getCurrentUser().getUser();
+  
+      // Existing schedules
+      PersonalSchedule existingSchedule1 =
+          PersonalSchedule.builder()
+              .name("TestName")
+              .quarter("20222")
+              .description("Existing description 1")
+              .user(thisUser)
+              .id(1L)
+              .build();
+  
+      PersonalSchedule existingSchedule2 =
+          PersonalSchedule.builder()
+              .name("AnotherName")
+              .quarter("20222")
+              .description("Existing description 2")
+              .user(thisUser)
+              .id(3L)
+              .build();
+  
+      Iterable<PersonalSchedule> allSchedules =
+          Arrays.asList(existingSchedule1, existingSchedule2);
+  
+      // Case 1: Same name and same quarter (Should detect as duplicate)
+      PersonalSchedule incomingSchedule1 =
+          PersonalSchedule.builder()
+              .name("TestName")
+              .quarter("20222")
+              .description("Updated description")
+              .id(3L)
+              .user(thisUser)
+              .build();
+  
+      when(personalscheduleRepository.findAllByUserId(thisUser.getId())).thenReturn(allSchedules);
+  
+      boolean duplicateExists1 =
+          StreamSupport.stream(allSchedules.spliterator(), false)
+              .anyMatch(
+                  schedule ->
+                      schedule.getName().equals(incomingSchedule1.getName()) &&
+                      schedule.getQuarter().equals(incomingSchedule1.getQuarter()) &&
+                      schedule.getId() != incomingSchedule1.getId());
+  
+      assertTrue(duplicateExists1);
+  
+      // Case 2: Same name but different quarter (Should NOT detect as duplicate)
+      PersonalSchedule incomingSchedule2 =
+          PersonalSchedule.builder()
+              .name("TestName")
+              .quarter("20223")
+              .description("Updated description")
+              .id(4L) 
+              .user(thisUser)
+              .build();
+  
+      boolean duplicateExists2 =
+          StreamSupport.stream(allSchedules.spliterator(), false)
+              .anyMatch(
+                  schedule ->
+                      schedule.getName().equals(incomingSchedule2.getName()) &&
+                      schedule.getQuarter().equals(incomingSchedule2.getQuarter()) &&
+                      schedule.getId() != incomingSchedule2.getId());
+  
+      assertFalse(duplicateExists2);
+  
+      // Case 3: Same quarter but different name (Should NOT detect as duplicate)
+      PersonalSchedule incomingSchedule3 =
+          PersonalSchedule.builder()
+              .name("DifferentName")
+              .quarter("20222")
+              .description("Different description")
+              .id(5L)
+              .user(thisUser)
+              .build();
+  
+      boolean duplicateExists3 =
+          StreamSupport.stream(allSchedules.spliterator(), false)
+              .anyMatch(
+                  schedule ->
+                      schedule.getName().equals(incomingSchedule3.getName()) &&
+                      schedule.getQuarter().equals(incomingSchedule3.getQuarter()) &&
+                      schedule.getId() != incomingSchedule3.getId());
+  
+      assertFalse(duplicateExists3);
+  
+    //   Case 4: Different name and different quarter (Should NOT detect as duplicate)
+      PersonalSchedule incomingSchedule4 =
+          PersonalSchedule.builder()
+              .name("DifferentName")
+              .quarter("20223")
+              .description("Different description")
+              .id(6L)
+              .user(thisUser)
+              .build();
+  
+      boolean duplicateExists4 =
+          StreamSupport.stream(allSchedules.spliterator(), false)
+              .anyMatch(
+                  schedule ->
+                      schedule.getName().equals(incomingSchedule4.getName()) &&
+                      schedule.getQuarter().equals(incomingSchedule4.getQuarter()) &&
+                      schedule.getId() != incomingSchedule4.getId());
+  
+      assertFalse(duplicateExists4); 
+  }
+  
 }


### PR DESCRIPTION
Closes [#1]. This features now no longer has the bug where a user is able to edit a personal schedule's name to be one of an existing personal schedule of that same quarter. 

Link to dokku deployment:
https://courses-dev-vincentc0202.dokku-01.cs.ucsb.edu/