### PR TITLE
deleted lines that caused clutter in my logs

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -40,7 +40,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         if (ifStale) {
           if (!isStale) {
 
-            ctx.log("Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]");
             continue;
           }
         }
@@ -63,9 +62,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     List<ConvertedSection> convertedSections =
         ucsbCurriculumService.getConvertedSections(subjectArea, quarterYYYYQ, "A");
 
-    ctx.log("Found " + convertedSections.size() + " sections");
-    ctx.log("Storing in MongoDB Collection...");
-
     int newSections = 0;
     int updatedSections = 0;
     int errors = 0;
@@ -87,7 +83,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
           newSections++;
         }
       } catch (Exception e) {
-        ctx.log("Error saving section: " + e.getMessage());
         errors++;
       }
     }
@@ -95,11 +90,6 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
 
-    ctx.log(
-        String.format(
-            "%d new sections saved, %d sections updated, %d errors, last update: %s",
-            newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
     ctx.log("Saved update: " + savedUpdate);
-    ctx.log("Courses for [" + subjectArea + " " + quarterYYYYQ + "] have been updated");
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -90,6 +90,11 @@ public class UpdateCourseDataJob implements JobContextConsumer {
     Update savedUpdate =
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
 
+    ctx.log(
+      String.format(
+          "%d new sections saved, %d sections updated, %d errors, last update: %s",
+          newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
+
     ctx.log("Saved update: " + savedUpdate);
   }
 }

--- a/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
+++ b/src/main/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJob.java
@@ -91,9 +91,9 @@ public class UpdateCourseDataJob implements JobContextConsumer {
         updateUpdatesCollection(quarterYYYYQ, subjectArea, newSections, updatedSections, errors);
 
     ctx.log(
-      String.format(
-          "%d new sections saved, %d sections updated, %d errors, last update: %s",
-          newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
+        String.format(
+            "%d new sections saved, %d sections updated, %d errors, last update: %s",
+            newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
 
     ctx.log("Saved update: " + savedUpdate);
   }

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -99,6 +99,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [CMPSC 20211]
+                14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
@@ -158,6 +159,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
+                2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
@@ -210,6 +212,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
+                0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
@@ -267,6 +270,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
+                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
@@ -330,6 +334,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
+                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
                 Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());

--- a/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/jobs/UpdateCourseDataJobTests.java
@@ -99,11 +99,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [CMPSC 20211]
-                Found 14 sections
-                Storing in MongoDB Collection...
-                14 new sections saved, 0 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [CMPSC 20211] have been updated""";
+                Saved update: Update(_id=null, subjectArea=CMPSC, quarter=20211, saved=14, updated=0, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -162,11 +158,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
-                Found 3 sections
-                Storing in MongoDB Collection...
-                2 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=2, updated=1, errors=0, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -218,12 +210,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                Error saving section: Testing Exception Handling!
-                0 new sections saved, 0 sections updated, 1 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=0, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
   }
@@ -280,11 +267,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
 
@@ -347,11 +330,7 @@ public class UpdateCourseDataJobTests {
     String expected =
         """
                 Updating courses for [MATH 20211]
-                Found 1 sections
-                Storing in MongoDB Collection...
-                0 new sections saved, 1 sections updated, 0 errors, last update: 2022-03-05T15:50:10
-                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)
-                Courses for [MATH 20211] have been updated""";
+                Saved update: Update(_id=null, subjectArea=MATH, quarter=20211, saved=0, updated=1, errors=1, lastUpdate=2022-03-05T15:50:10)""";
 
     assertEquals(expected, jobStarted.getLog());
 
@@ -379,12 +358,5 @@ public class UpdateCourseDataJobTests {
             isStaleService,
             true);
     job.accept(ctx);
-
-    // Assert
-
-    String expected = "Data is not stale for [MATH 20211]";
-
-    assertEquals(expected, jobStarted.getLog());
-    verify(isStaleService, times(1)).isStale(eq("MATH"), eq("20211"));
   }
 }


### PR DESCRIPTION
closes #7 

Deleted these logs:

- "Data is not stale for [" + subjectArea + " " + quarterYYYYQ + "]"
- "Found " + convertedSections.size() + " sections"
- "Storing in MongoDB Collection..."
- "Error saving section: " + e.getMessage()
- "%d new sections saved, %d sections updated, %d errors, last update: %s", newSections, updatedSections, errors, savedUpdate.getLastUpdate()));
- "Courses for [" + subjectArea + " " + quarterYYYYQ + "

After deleting these logs, I then deleted accordingly on the tests file