### PR TITLE
Fix backend error message bug when adding a different section from an existing course in personal schedule.

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -119,6 +119,12 @@ export const onSuccess = (response) => {
   );
 };
 
+export const onError = (error) => {
+  const message =
+    error.response?.data?.message || "An unexpected error occurred";
+  toast.error(message);
+};
+
 export default function SectionsTable({ sections }) {
   // Stryker restore all
   // Stryker disable BooleanLiteral
@@ -126,7 +132,7 @@ export default function SectionsTable({ sections }) {
 
   const mutation = useBackendMutation(
     objectToAxiosParams,
-    { onSuccess },
+    { onSuccess, onError },
     // Stryker disable next-line all : hard to set up test for caching
     ["/api/courses/user/all"],
   );

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -24,10 +24,11 @@ jest.mock("react-router-dom", () => ({
   useNavigate: () => mockedNavigate,
 }));
 
-jest.mock("react-toastify", () => ({
-  toast: jest.fn(),
-}));
-
+jest.mock("react-toastify", () => {
+  const toast = jest.fn();
+  toast.error = jest.fn();
+  return { toast };
+});
 jest.mock("main/utils/useBackend", () => ({
   useBackendMutation: jest.fn(),
 }));
@@ -424,6 +425,84 @@ describe("Section tests", () => {
     expect(toast).toHaveBeenCalledWith(
       "New course Created - id: 1 enrollCd: 1234",
     );
+  });
+
+  test("calls onError when mutation throws an error and calls toast with correct parameters", () => {
+    const mockMutate = jest.fn();
+    const mockMutation = { mutate: mockMutate };
+
+    useBackendMutation.mockReturnValue(mockMutation);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Call the onSuccess function
+    const onError = useBackendMutation.mock.calls[0][1].onError;
+    const mockResponse = {
+      response: {
+        data: {
+          message: "class exists in schedule",
+        },
+      },
+    };
+    onError(mockResponse);
+
+    // Verify that toast was called with the correct parameters
+    expect(toast.error).toHaveBeenCalledWith("class exists in schedule");
+  });
+
+  test("calls toast.error with default message when error message is undefined", () => {
+    const mockMutate = jest.fn();
+    const mockMutation = { mutate: mockMutate };
+
+    useBackendMutation.mockReturnValue(mockMutation);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const onError = useBackendMutation.mock.calls[0][1].onError;
+
+    const mockError = {}; // No response or message
+    onError(mockError);
+
+    expect(toast.error).toHaveBeenCalledWith("An unexpected error occurred");
+  });
+
+  test("onError displays default message when error.response.data is undefined", () => {
+    const mockMutate = jest.fn();
+    const mockMutation = { mutate: mockMutate };
+
+    useBackendMutation.mockReturnValue(mockMutation);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const onError = useBackendMutation.mock.calls[0][1].onError;
+
+    const mockError = {
+      response: {
+        data: undefined,
+      },
+    };
+
+    onError(mockError);
+
+    expect(toast.error).toHaveBeenCalledWith("An unexpected error occurred");
   });
 
   test("renders without crashing for empty table", () => {


### PR DESCRIPTION
Users can add courses and sections to their personal schedules within the app. Each course has multiple sections. Currently, an unreadable error message pops up if a user adds a course + section to their schedule and then tries to add a different section from the same course. This card was meant to make the error message easier for the user to read.  Closes #5.

Deployment:  https://courses-dev-realweston34.dokku-01.cs.ucsb.edu



https://github.com/user-attachments/assets/46e4e031-cda9-47ec-bde8-e9cc0e86c1c5

