### PR TITLE
Allow users to replace sections on personal schedule

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -114,9 +114,15 @@ export const handleLectureAddToSchedule = (section, schedule, mutation) => {
 };
 
 export const onSuccess = (response) => {
-  toast(
-    `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`,
-  );
+  if (response.length < 3) {
+    toast(
+      `New course Created - id: ${response[0].id} enrollCd: ${response[0].enrollCd}`,
+    );
+  } else {
+    toast(
+      `Course ${response[0].enrollCd} replaced old section ${response[2].enrollCd} with new section ${response[1].enrollCd}`,
+    );
+  }
 };
 
 export const onError = (error) => {

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -427,6 +427,33 @@ describe("Section tests", () => {
     );
   });
 
+  test("calls onSuccess when mutation is successful for replacement and calls toasy with correct parameters", () => {
+    const mockMutate = jest.fn();
+    const mockMutation = { mutate: mockMutate };
+
+    useBackendMutation.mockReturnValue(mockMutation);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const onSuccess = useBackendMutation.mock.calls[0][1].onSuccess;
+    const mockResponse = [
+      { id: 1, enrollCd: "1234" },
+      { id: 2, enrollCd: "5678" },
+      { id: 3, enrollCd: "9012" },
+    ];
+    onSuccess(mockResponse);
+
+    expect(toast).toHaveBeenCalledWith(
+      "Course 1234 replaced old section 9012 with new section 5678",
+    );
+  });
+
   test("calls onError when mutation throws an error and calls toast with correct parameters", () => {
     const mockMutate = jest.fn();
     const mockMutation = { mutate: mockMutate };

--- a/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
+++ b/src/test/java/edu/ucsb/cs156/courses/documents/SectionFixtures.java
@@ -429,6 +429,184 @@ public class SectionFixtures {
     }
     """;
 
+  public static final String SECTION_JSON_CMPSC156_UNEXPECTED_REVERSED =
+      """
+  {
+    "quarter": "20221",
+    "courseId": "CMPSC   156  ",
+    "title": "ADV APP PROGRAM",
+    "contactHours": 30,
+    "description": "Advanced application programming using a high-level, virtual-machine-based language. Topics include generic programming, exception handling, automatic memory management, and application development, management, and maintenance tools, third-party library use, version control, software testing, issue tracking, code review, and working with legacy code.",
+    "college": "ENGR",
+    "objLevelCode": "U",
+    "subjectArea": "CMPSC   ",
+    "unitsFixed": 4,
+    "unitsVariableHigh": null,
+    "unitsVariableLow": null,
+    "delayedSectioning": null,
+    "inProgressCourse": null,
+    "gradingOption": "L",
+    "instructionType": "LEC",
+    "onLineCourse": false,
+    "deptCode": "CMPSC",
+    "generalEducation": [],
+    "classSections": [
+      {
+        "enrollCode": "08326",
+        "section": "0103",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 24,
+        "maxEnroll": 24,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "3525",
+            "building": "PHELP",
+            "roomCapacity": null,
+            "days": " T     ",
+            "beginTime": "19:00",
+            "endTime": "19:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "LU A H",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "HEFFERNAN K J",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      },
+      {
+        "enrollCode": "08318",
+        "section": "0102",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 24,
+        "maxEnroll": 24,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "3525",
+            "building": "PHELP",
+            "roomCapacity": null,
+            "days": " T     ",
+            "beginTime": "18:00",
+            "endTime": "18:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "HEFFERNAN K J",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "LU A H",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      },
+      {
+        "enrollCode": "08292",
+        "section": "0100",
+        "session": null,
+        "classClosed": "Y",
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 72,
+        "maxEnroll": 72,
+        "secondaryStatus": "R",
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "1431",
+            "building": "SH",
+            "roomCapacity": 76,
+            "days": "M W    ",
+            "beginTime": "12:30",
+            "endTime": "13:45"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "CONRAD P T",
+            "functionCode": "Teaching and in charge"
+          }
+        ]
+      },
+      {
+        "enrollCode": "08300",
+        "section": "0101",
+        "session": null,
+        "classClosed": null,
+        "courseCancelled": null,
+        "gradingOptionCode": null,
+        "enrolledTotal": 24,
+        "maxEnroll": 24,
+        "secondaryStatus": null,
+        "departmentApprovalRequired": false,
+        "instructorApprovalRequired": false,
+        "restrictionLevel": null,
+        "restrictionMajor": "+CMPSC+CMPEN+CPSCI",
+        "restrictionMajorPass": null,
+        "restrictionMinor": null,
+        "restrictionMinorPass": null,
+        "concurrentCourses": [],
+        "timeLocations": [
+          {
+            "room": "3525",
+            "building": "PHELP",
+            "roomCapacity": null,
+            "days": " T     ",
+            "beginTime": "17:00",
+            "endTime": "17:50"
+          }
+        ],
+        "instructors": [
+          {
+            "instructor": "LU A H",
+            "functionCode": "Teaching but not in charge"
+          },
+          {
+            "instructor": "HEFFERNAN K J",
+            "functionCode": "Teaching but not in charge"
+          }
+        ]
+      }
+    ]
+  }
+  """;
+
   public static final String SECTION_JSON_CMPSC291A =
       """
     {


### PR DESCRIPTION
Previously, if a user wanted to change a section, they would have to delete the previous section and add the new one from the main course page. This feature allows the user to replace an existing section linked to a course with a new section directly from the main course page. Closes #26.

deployment: https://courses-dev-realweston34.dokku-01.cs.ucsb.edu/


https://github.com/user-attachments/assets/77263f3e-5f86-4baa-b305-18b56c2c19d3

